### PR TITLE
Update HOTP.php

### DIFF
--- a/src/SURFnet/OATHBundle/OATH/HOTP.php
+++ b/src/SURFnet/OATHBundle/OATH/HOTP.php
@@ -2,7 +2,7 @@
 
 namespace SURFnet\OATHBundle\OATH;
 
-class HOTP extends AbstractOath
+class HOTP extends AbstractOATH
 {
     /**
      * Calculate a HOTP response


### PR DESCRIPTION
Inconsistent casing leads to PHP Fatal errors  (Class 'SURFnet\OATHBundle\OATH\AbstractOath' not found).
Don't know whether AbstractOATH or AbstractOath is preferred, but I suggest to choose the former.
