### PR TITLE
Fix http status code

### DIFF
--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -1,12 +1,15 @@
 monolog:
-  handlers:
-    main:
-      type:         fingers_crossed
-      action_level: error
-      handler:      nested
-    nested:
-      type:  stream
-      path:  "%kernel.logs_dir%/%kernel.environment%.log"
-      level: debug
-    console:
-      type:  console
+    handlers:
+        prod-signaler:
+            type: fingers_crossed
+            action_level: ERROR
+            passthru_level: NOTICE # this means that all message of level NOTICE or higher are always logged
+            handler: main_syslog
+            bubble: false # if we handle it, nothing else should
+        main_syslog:
+            type: syslog
+            ident: stepup-keyserver
+            facility: user
+        console:
+            type: console
+            process_psr_3_messages: false

--- a/src/SURFnet/OATHBundle/Controller/OathController.php
+++ b/src/SURFnet/OATHBundle/Controller/OathController.php
@@ -30,7 +30,11 @@ class OathController extends BaseController
             $data = $this->ocra->generateChallenge();
         } catch (\Exception $e) {
             $data = array('error' => $e->getMessage());
-            $responseCode = $e->getCode() ?: 500;
+            $responseCode = 500;
+            // only pass error code is it's a valid http status code
+            if ($e->getCode() >= 200 && $e->getCode() <= 510) {
+                $responseCode = $e->getCode() ?: 500;
+            }
         }
         return $this->view($data, $responseCode);
     }
@@ -71,8 +75,12 @@ class OathController extends BaseController
                 $responseCode = 400;
             }
         } catch (\Exception $e) {
-            $data = array('error' => $e->getMessage(), 'trace' => $e->getTraceAsString(),);
-            $responseCode = $e->getCode() ?: 500;
+            $data = array('error' => $e->getMessage());
+            $responseCode = 500;
+            // only pass error code is it's a valid http status code
+            if ($e->getCode() >= 200 && $e->getCode() <= 510) {
+                $responseCode = $e->getCode() ?: 500;
+            }
         }
         return $this->view($data, $responseCode);
     }
@@ -106,8 +114,12 @@ class OathController extends BaseController
                 $responseCode = 400;
             }
         } catch (\Exception $e) {
-            $data = array('error' => $e->getMessage(), 'trace' => $e->getTraceAsString());
-            $responseCode = $e->getCode() ?: 500;
+            $data = array('error' => $e->getMessage());
+            $responseCode = 500;
+            // only pass error code is it's a valid http status code
+            if ($e->getCode() >= 200 && $e->getCode() <= 510) {
+                $responseCode = $e->getCode() ?: 500;
+            }
         }
         return $this->view($data, $responseCode);
     }
@@ -141,8 +153,12 @@ class OathController extends BaseController
                 $responseCode = 400;
             }
         } catch (\Exception $e) {
-            $data = array('error' => $e->getMessage(), 'trace' => $e->getTraceAsString(),);
-            $responseCode = $e->getCode() ?: 500;
+            $data = array('error' => $e->getMessage());
+            $responseCode = 500;
+            // only pass error code is it's a valid http status code
+            if ($e->getCode() >= 200 && $e->getCode() <= 510) {
+                $responseCode = $e->getCode() ?: 500;
+            }
         }
         return $this->view($data, $responseCode);
     }

--- a/src/SURFnet/OATHBundle/Controller/SecretsController.php
+++ b/src/SURFnet/OATHBundle/Controller/SecretsController.php
@@ -35,7 +35,12 @@ class SecretsController extends BaseController
             $this->userStorage->saveSecret($identifier, $request->get('secret'));
         } catch (\Exception $e) {
             $data = array('error' => $e->getMessage());
-            $responseCode = $e->getCode() ?: 500;
+            // only pass error code is it's a valid http status code
+            if ($e->getCode() >= 200 && $e->getCode() <= 510) {
+                $responseCode = $e->getCode() ?: 500;
+            } else {
+                $responseCode = 500;
+            }
         }
         return $this->view($data, $responseCode);
     }
@@ -64,7 +69,12 @@ class SecretsController extends BaseController
             $data = $this->userStorage->deleteSecret($identifier);
         } catch (\Exception $e) {
             $data = array('error' => $e->getMessage());
-            $responseCode = $e->getCode() ?: 500;
+            // only pass error code is it's a valid http status code
+            if ($e->getCode() >= 200 && $e->getCode() <= 510) {
+                $responseCode = $e->getCode() ?: 500;
+            } else {
+                $responseCode = 500;
+            }
         }
         return $this->view($data, $responseCode);
     }


### PR DESCRIPTION
The php-error codes were added as http-status-code. This causes problems when other (eg. database) errors occur that use non-http error numvers